### PR TITLE
Running tests on port 9876 instead of 3000

### DIFF
--- a/test/integration/support/integrationSpecHelper.js
+++ b/test/integration/support/integrationSpecHelper.js
@@ -1,5 +1,6 @@
 const Zombie = require('zombie');
-Zombie.site = 'http://localhost:3000';
+const appPort = '9876';
+Zombie.site = `http://localhost:${appPort}`;
 const browser = new Zombie();
 const screenshots = require('./screenshots');
 const GoogleTagManagerHelper = require('../../common/page_objects/google-tag-manager-helper');
@@ -8,6 +9,7 @@ const SearchPage = require('../../common/page_objects/search-page');
 const ErrorPage = require('../../common/page_objects/error-page');
 
 process.env.GOOGLE_TAG_MANAGER_ID = 'fake-id';
+process.env.PORT = appPort;
 const app = require('../../../bin/www');
 
 afterEach(function () {


### PR DESCRIPTION
This allows to run tests and work in `watch` mode