### PR TITLE
implement category link on search page

### DIFF
--- a/app/views/search.mustache
+++ b/app/views/search.mustache
@@ -38,7 +38,7 @@
         <ul aria-label="tags" class="search-result-metadata">
           {{#category}}
             <li class="search-result-category" data-test="category">
-              <a href="#{{ . }}">{{.}}</a>
+              <a href="{{ basePath }}/search?search={{ . }}" data-test="category-link">{{ . }}</a>
             </li>
           {{/category}}
 

--- a/test/common/page_objects/page.js
+++ b/test/common/page_objects/page.js
@@ -1,0 +1,29 @@
+class Page {
+
+  constructor(browser) {
+    this.browser = browser;
+  }
+
+  /**
+   * @param {string} dataTest - the data test element
+   * @param {object} context - the core object returned from browser.querySelector
+   * returns the text within the element
+   */
+  extractText(dataTest, context) {
+    return this.browser.text(`[data-test="${dataTest}"]`, context);
+  }
+
+
+  /**
+   * @param {string} dataTest - the data test element
+   * @param {object} context - the 'core' object returned from browser.querySelector
+   * returns the text within the element
+   */
+  extractLink(dataTest, context) {
+    const href = this.browser.query(`[data-test="${dataTest}"]`, context).href;
+    const text = this.extractText(dataTest, context);
+    return { href, text };
+  }
+
+}
+module.exports = Page;

--- a/test/common/page_objects/search-page.js
+++ b/test/common/page_objects/search-page.js
@@ -25,7 +25,14 @@ class SearchPage {
       title: this.extractText('title', context),
       summary: this.extractText('summary', context),
       categories: this.browser.queryAll('[data-test="category"]', context)
-        .map(i => this.browser.text(i)),
+        .map(categoryContext => Object({
+          text: this.browser.text(categoryContext),
+          link: (() => {
+            const categoryLink = this.browser.query('[data-test="category-link"]', categoryContext);
+            return `${categoryLink.pathname}${categoryLink.search}`;
+          })(),
+        })
+      ),
       pathname: this.browser.query('[data-test^="resource-"]', context).pathname,
     }));
   }

--- a/test/common/page_objects/search-page.js
+++ b/test/common/page_objects/search-page.js
@@ -1,7 +1,6 @@
-class SearchPage {
-  constructor(browser) {
-    this.browser = browser;
-  }
+const Page = require('./page');
+
+class SearchPage extends Page {
 
   visit() {
     return this.browser.visit('/search');
@@ -11,29 +10,26 @@ class SearchPage {
     return this.browser.text('[data-test="header"]');
   }
 
-  extractText(name, context) {
-    return this.browser.text(`[data-test="${name}"]`, context);
-  }
-
   clickOnResourse(resourceId) {
     return this.browser.click(`[data-test="resource-${resourceId}"]`);
   }
 
+  /**
+   * @param {object} resourceContext - the context object for the resource
+   * returns a list of categories as an object: { text, href }.
+   */
+  getCategories(resourceContext) {
+    return this.browser.queryAll('[data-test="category"]', resourceContext)
+      .map(categoryContext => this.extractLink('category-link', categoryContext));
+  }
+
   getResults() {
     const resources = this.browser.queryAll('[data-test="resource"]');
-    return resources.map(context => ({
-      title: this.extractText('title', context),
-      summary: this.extractText('summary', context),
-      categories: this.browser.queryAll('[data-test="category"]', context)
-        .map(categoryContext => Object({
-          text: this.browser.text(categoryContext),
-          link: (() => {
-            const categoryLink = this.browser.query('[data-test="category-link"]', categoryContext);
-            return `${categoryLink.pathname}${categoryLink.search}`;
-          })(),
-        })
-      ),
-      pathname: this.browser.query('[data-test^="resource-"]', context).pathname,
+    return resources.map(resourceContext => ({
+      title: this.extractText('title', resourceContext),
+      summary: this.extractText('summary', resourceContext),
+      categories: this.getCategories(resourceContext),
+      href: this.browser.query('[data-test^="resource-"]', resourceContext).href,
     }));
   }
 

--- a/test/integration/search.spec.js
+++ b/test/integration/search.spec.js
@@ -30,8 +30,12 @@ describe('Search', () => {
       expect(this.resourceList.map(i => i.summary)).to.eql(resourcesListModel.map(i => i.summary))
     );
     it('should display correct categories for all resources', () =>
-      expect(this.resourceList.map(i => i.categories))
+      expect(this.resourceList.map(i => i.categories.map(j => j.text)))
         .to.eql(resourcesListModel.map(i => i.category))
+    );
+    it('should contain correct link to all categories for all resources', () =>
+      expect(this.resourceList.map(i => i.categories.map(j => j.link)))
+        .to.eql(resourcesListModel.map(i => i.category.map(j => encodeURI(`/search?search=${j}`))))
     );
     it('should have correct path for all resources details page', () =>
       expect(this.resourceList.map(i => i.pathname))

--- a/test/integration/search.spec.js
+++ b/test/integration/search.spec.js
@@ -1,4 +1,4 @@
-const { searchPage, googleTagManagerHelper } = require('./support/integrationSpecHelper');
+const { searchPage, googleTagManagerHelper, browser } = require('./support/integrationSpecHelper');
 const expect = require('chai').expect;
 const { describe, it, before } = require('mocha');
 const resourcesListModel = require('../../app/data/resources');
@@ -34,12 +34,13 @@ describe('Search', () => {
         .to.eql(resourcesListModel.map(i => i.category))
     );
     it('should contain correct link to all categories for all resources', () =>
-      expect(this.resourceList.map(i => i.categories.map(j => j.link)))
-        .to.eql(resourcesListModel.map(i => i.category.map(j => encodeURI(`/search?search=${j}`))))
+      expect(this.resourceList.map(i => i.categories.map(j => j.href)))
+        .to.eql(resourcesListModel.map(i =>
+                  i.category.map(j => encodeURI(`${browser.site}/search?search=${j}`))))
     );
     it('should have correct path for all resources details page', () =>
-      expect(this.resourceList.map(i => i.pathname))
-        .to.eql(resourcesListModel.map(i => `/resources/${i.resourceId}`))
+      expect(this.resourceList.map(i => i.href))
+        .to.eql(resourcesListModel.map(i => `${browser.site}/resources/${i.resourceId}`))
     );
   });
 


### PR DESCRIPTION
Adds a link for each of the search results' categories, which, when clicked, links the user to the same search page with the category name as the search query