### PR TITLE
implement category link from details page

### DIFF
--- a/app/views/detail.mustache
+++ b/app/views/detail.mustache
@@ -2,7 +2,7 @@
     {{$pageTitle}}{{#__}}detail.pageTitle{{/__}}{{/pageTitle}}
     {{$applicationContent}}
         {{#resource}}
-            <a data-test="category">{{ category.0 }}</a>
+            <a href="/search?search={{ category.0 }}" data-test="category">{{ category.0 }}</a>
             <h2 class="heading-xlarge" data-test="header">{{ title }}</h2>
             <p class="description text" data-test="summary">{{ summary }}</p>
             <h3>{{#__}}detail.howToUseIt.header{{/__}}</h3>

--- a/test/common/page_objects/detail-page.js
+++ b/test/common/page_objects/detail-page.js
@@ -11,8 +11,13 @@ class DetailPage {
     return this.browser.text(`[data-test="${dataTestAttrVal}"]`);
   }
 
-  category() {
+  categoryText() {
     return this.text('category');
+  }
+
+  categoryLink() {
+    const catEl = this.browser.query('[data-test="category"]');
+    return `${catEl.pathname}${catEl.search}`;
   }
 
   header() {

--- a/test/common/page_objects/detail-page.js
+++ b/test/common/page_objects/detail-page.js
@@ -1,43 +1,32 @@
-class DetailPage {
-  constructor(browser) {
-    this.browser = browser;
-  }
+const Page = require('./page');
+class DetailPage extends Page {
 
   visit(id) {
     return this.browser.visit(`/resources/${id}`);
   }
 
-  text(dataTestAttrVal) {
-    return this.browser.text(`[data-test="${dataTestAttrVal}"]`);
-  }
-
   categoryText() {
-    return this.text('category');
+    return this.extractText('category');
   }
 
   categoryLink() {
-    const catEl = this.browser.query('[data-test="category"]');
-    return `${catEl.pathname}${catEl.search}`;
-  }
-
-  header() {
-    return this.text('header');
-  }
-
-  summary() {
-    return this.text('summary');
-  }
-
-  journalMessage() {
-    return this.text('journal-message');
+    return this.extractLink('category').href;
   }
 
   link() {
-    return this.browser.query('[data-test="link"]').href;
+    return this.extractLink('link');
   }
 
-  linkText() {
-    return this.text('link');
+  header() {
+    return this.extractText('header');
+  }
+
+  summary() {
+    return this.extractText('summary');
+  }
+
+  journalMessage() {
+    return this.extractText('journal-message');
   }
 
 }

--- a/test/common/page_objects/page.js
+++ b/test/common/page_objects/page.js
@@ -6,20 +6,22 @@ class Page {
 
   /**
    * @param {string} dataTest - the data test element
-   * @param {object} context - the core object returned from browser.querySelector
+   * @param {object} context - the core object returned from browser.querySelector. By default
+   * uses the document
    * returns the text within the element
    */
-  extractText(dataTest, context) {
+  extractText(dataTest, context = this.browser) {
     return this.browser.text(`[data-test="${dataTest}"]`, context);
   }
 
 
   /**
    * @param {string} dataTest - the data test element
-   * @param {object} context - the 'core' object returned from browser.querySelector
+   * @param {object} context - the 'core' object returned from browser.querySelector. By default
+   * uses the document
    * returns the text within the element
    */
-  extractLink(dataTest, context) {
+  extractLink(dataTest, context = this.browser) {
     const href = this.browser.query(`[data-test="${dataTest}"]`, context).href;
     const text = this.extractText(dataTest, context);
     return { href, text };

--- a/test/integration/detail.spec.js
+++ b/test/integration/detail.spec.js
@@ -1,7 +1,8 @@
 const {
   googleTagManagerHelper,
   detailPage,
-  searchPage } = require('./support/integrationSpecHelper');
+  searchPage,
+  browser } = require('./support/integrationSpecHelper');
 const chai = require('chai');
 chai.use(require('chai-string'));
 const expect = chai.expect;
@@ -22,7 +23,8 @@ describe('Detail', () => {
       expect(detailPage.categoryText()).to.equal(sampleResource.category[0]));
 
     it('should link first category to search page', () =>
-      expect(detailPage.categoryLink()).to.equal(`/search?search=${sampleResource.category[0]}`));
+      expect(detailPage.categoryLink())
+        .to.equal(`${browser.site}/search?search=${sampleResource.category[0]}`));
 
     it('should display title', () =>
       expect(detailPage.header()).to.equal(sampleResource.title)
@@ -37,11 +39,11 @@ describe('Detail', () => {
     );
 
     it('should display link', () =>
-      expect(detailPage.link()).to.equal(sampleResource.url)
+      expect(detailPage.link().href).to.equal(sampleResource.url)
     );
 
     it('should display link text', () =>
-      expect(detailPage.linkText()).to.equal('Check it out')
+      expect(detailPage.link().text).to.equal('Check it out')
     );
   });
 

--- a/test/integration/detail.spec.js
+++ b/test/integration/detail.spec.js
@@ -19,7 +19,10 @@ describe('Detail', () => {
     );
 
     it('should display first category', () =>
-      expect(detailPage.category()).to.equal(sampleResource.category[0]));
+      expect(detailPage.categoryText()).to.equal(sampleResource.category[0]));
+
+    it('should link first category to search page', () =>
+      expect(detailPage.categoryLink()).to.equal(`/search?search=${sampleResource.category[0]}`));
 
     it('should display title', () =>
       expect(detailPage.header()).to.equal(sampleResource.title)


### PR DESCRIPTION
adds the link from category on details page to search result with category as the query for that search as per design.