### PR TITLE
Feature/resource 404

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -9,6 +9,7 @@ const dashboardController = require('./controllers/dashboard-controller');
 const searchController = require('./controllers/search-controller');
 const detailController = require('./controllers/detail-controller');
 const cookieController = require('./controllers/cookie-controller');
+const errorController = require('./controllers/error-controller');
 const i18n = require('./middleware/i18n');
 const errorHandler = require('./middleware/error-handler');
 const tidyUrl = require('./middleware/tidy-url');
@@ -86,6 +87,10 @@ app.use(`${basePath}/`, dashboardController);
 app.use(`${basePath}/`, searchController);
 app.use(`${basePath}/`, detailController);
 app.use(`${basePath}/`, cookieController);
+
+if (/^development|test$/.test(app.get('env'))) {
+  app.use(`${basePath}/`, errorController);
+}
 
 // catch 404 and forward to error handler
 app.use((req, res, next) => {

--- a/app/app.js
+++ b/app/app.js
@@ -11,6 +11,7 @@ const detailController = require('./controllers/detail-controller');
 const cookieController = require('./controllers/cookie-controller');
 const i18n = require('./middleware/i18n');
 const errorHandler = require('./middleware/error-handler');
+const tidyUrl = require('./middleware/tidy-url');
 const healthCheckController = require('./controllers/health-check-controller');
 const helmet = require('helmet');
 const breadcrumbViewModel = require('./controllers/breadcrumb-view-model');
@@ -72,6 +73,8 @@ app.use(assetPath, express.static(path.join(__dirname, '..',
   'vendor', 'govuk_frontend_toolkit', 'assets')));
 
 app.use(helmet.noCache());
+
+app.use('*', tidyUrl);
 
 app.use((req, res, next) => {
   Object.assign(res.locals,

--- a/app/controllers/detail-controller.js
+++ b/app/controllers/detail-controller.js
@@ -3,8 +3,15 @@ const router = new express.Router();
 const { resourceModel } = require('../appContext');
 const { decorateWithCategories } = require('../decorators/resource-decorator');
 
-router.get('/resources/:id', (req, res) => {
-  res.render('detail', { resource: decorateWithCategories(resourceModel.findById(req.params.id)) });
+router.get('/resources/:id', (req, res, next) => {
+  const resource = resourceModel.findById(req.params.id);
+  if (!resource) {
+    const error = new Error('Resource not found');
+    error.status = 404;
+    next(error);
+  } else {
+    res.render('detail', { resource: decorateWithCategories(resource) });
+  }
 });
 
 module.exports = router;

--- a/app/controllers/error-controller.js
+++ b/app/controllers/error-controller.js
@@ -1,0 +1,11 @@
+/* eslint-disable no-underscore-dangle */
+const express = require('express');
+const router = new express.Router();
+
+router.get('/error/:id', (req, res, next) => {
+  const e = new Error('Test error');
+  e.status = req.params.id || 500;
+  next(e);
+});
+
+module.exports = router;

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -1,4 +1,12 @@
 {
+  "404": {
+    "pagetitle": "Page not found",
+    "message": "There's nothing here. The page may have moved or been removed.",
+    "searchagain": {
+      "link": "Search again",
+      "subtext": "to find more resources."
+    }
+  },
   "cookie": {
     "pretext": "GOV.UK uses cookies to make the site simpler",
     "linktext": "Find out more about cookies",

--- a/app/middleware/tidy-url.js
+++ b/app/middleware/tidy-url.js
@@ -1,0 +1,16 @@
+const express = require('express');
+const router = new express.Router();
+const url = require('url');
+
+router.get('*', (req, res, next) => {
+  const path = req.baseUrl;
+  const pathDedupeSlash = path
+    .replace(/\/+/g, '/')
+    .replace(/[\/]*$/g, ''); // If the last character in the path is a slash, express removes it
+  if (path !== pathDedupeSlash) {
+    return res.redirect(url.format({ pathname: pathDedupeSlash, query: req.query }));
+  }
+  return next();
+});
+
+module.exports = router;

--- a/app/views/404.mustache
+++ b/app/views/404.mustache
@@ -8,7 +8,7 @@
   <div class="column-full">
     <span data-test="message">
       <p>{{#__}}404.message{{/__}}</p>
-      <p><a href="{{ basePath }}/search">{{#__}}404.searchagain.link{{/__}}</a> {{#__}}404.searchagain.subtext{{/__}}</p>
+      <p><a href="{{ basePath }}/">{{#__}}404.searchagain.link{{/__}}</a> {{#__}}404.searchagain.subtext{{/__}}</p>
     </span>
   </div>
 </div>

--- a/app/views/404.mustache
+++ b/app/views/404.mustache
@@ -1,0 +1,17 @@
+{{<layout}}
+{{$pageTitle}}{{#__}}404.pagetitle{{/__}}{{/pageTitle}}
+{{$applicationContent}}
+<header class="page-header">
+  <h1 class="heading-large">{{#__}}404.pagetitle{{/__}}</h1>
+</header>
+<div class="grid-row">
+  <div class="column-full">
+    <span data-test="message">
+      <p>{{#__}}404.message{{/__}}</p>
+      <p><a href="{{ basePath }}/search">{{#__}}404.searchagain.link{{/__}}</a> {{#__}}404.searchagain.subtext{{/__}}</p>
+    </span>
+  </div>
+</div>
+
+{{/applicationContent}}
+{{/layout}}

--- a/app/views/dashboard.mustache
+++ b/app/views/dashboard.mustache
@@ -20,7 +20,7 @@
           <div class="column-one-third" data-test="category">
             <h3 class="heading-medium">
               <a href="{{ basePath }}/search?search={{ uriEncodedTitle }}" data-test="category-link">
-                {{ title }}</a>
+                {{ title }} BLAH BLAH</a>
             </h3>
             <p data-test="category-summary">{{ summary }}</p>
           </div>

--- a/test/common/page_objects/error-page.js
+++ b/test/common/page_objects/error-page.js
@@ -1,6 +1,7 @@
-class ErrorPage {
-  constructor({ browser }) {
-    this.browser = browser;
+const Page = require('./page');
+class ErrorPage extends Page {
+  visit(id) {
+    return this.browser.visit(this.routes.errorUrl(id));
   }
 
   getMessage() {

--- a/test/integration/detail.spec.js
+++ b/test/integration/detail.spec.js
@@ -4,6 +4,7 @@ const {
   searchPage,
   routes,
   browser } = require('./support/integrationSpecHelper');
+const url = require('url');
 const chai = require('chai');
 chai.use(require('chai-string'));
 const expect = chai.expect;
@@ -90,8 +91,25 @@ describe('Detail', () => {
     });
   });
 
-  it('should rediredct to 404 if no resource found', () =>
-    detailPage.visit('does-not-exist').catch(() => {})
-      .then(() => expect(browser.response.status).to.equal(404))
-  );
+  describe('tidyurl', () => {
+    const sampleResourcePath = url.parse(routes.detailsUrl(sampleResource.resourceId)).pathname;
+    it('should redirect to url with duplicate slash', () =>
+      detailPage.visit(`///${sampleResource.resourceId}///`).catch(() => {})
+        .then(() => expect(url.parse(browser.response.url).pathname)
+          .to.equal(sampleResourcePath)
+      )
+    );
+    it('should not redirect to url without duplicate slash', () =>
+      detailPage.visit(`${sampleResource.resourceId}`).catch(() => {})
+        .then(() => expect(url.parse(browser.response.url).pathname)
+          .to.equal(sampleResourcePath)
+      )
+    );
+    it('should not redirect to url without duplicate slash with trailing slash', () =>
+      detailPage.visit(`${sampleResource.resourceId}/`).catch(() => {})
+        .then(() => expect(url.parse(browser.response.url).pathname)
+          .to.equal(`${sampleResourcePath}/`)
+      )
+    );
+  });
 });

--- a/test/integration/detail.spec.js
+++ b/test/integration/detail.spec.js
@@ -2,7 +2,8 @@ const {
   googleTagManagerHelper,
   detailPage,
   searchPage,
-  routes } = require('./support/integrationSpecHelper');
+  routes,
+  browser } = require('./support/integrationSpecHelper');
 const chai = require('chai');
 chai.use(require('chai-string'));
 const expect = chai.expect;
@@ -88,4 +89,9 @@ describe('Detail', () => {
       expect(detailPage.getBreadcrumbs()).to.eql(['Home', 'Results', sampleResource.title]);
     });
   });
+
+  it('should rediredct to 404 if no resource found', () =>
+    detailPage.visit('does-not-exist').catch(() => {})
+      .then(() => expect(browser.response.status).to.equal(404))
+  );
 });

--- a/test/integration/error-handling.spec.js
+++ b/test/integration/error-handling.spec.js
@@ -17,11 +17,40 @@ describe('Error handling', () => {
       expect(errorPage.getErrorDetails()).to.equal('')
     );
     it('displays "Page not found" message', () =>
-      expect(errorPage.getMessage()).to.equal('Page not found')
+      expect(errorPage.getMessage()).to.equal(
+        'There\'s nothing here. The page may have moved or been removed. ' +
+        'Search again to find more resources.')
     );
 
     it('should contain valid google tag manager data', () =>
       expect(googleTagManagerHelper.getUserVariable()).to.exists
     );
+  });
+  describe('500', () => {
+    describe('test and development', () => {
+      before(() =>
+        errorPage.visit(500).catch(() => {})
+      );
+      it('should show error message', () =>
+        expect(errorPage.getErrorDetails()).to.contain('Test error 500 Error: Test error at ')
+      );
+      it('displays generic message', () =>
+        expect(errorPage.getMessage()).to.equal('We\'re experiencing technical problems.')
+      );
+    });
+    describe('production', () => {
+      const env = helper.app.get('env');
+      before(() => {
+        helper.app.set('env', 'production');
+        return errorPage.visit(500).catch(() => {});
+      });
+      it('should not show error message', () =>
+        expect(errorPage.getErrorDetails()).to.equal('')
+      );
+      it('displays generic message', () =>
+        expect(errorPage.getMessage()).to.equal('We\'re experiencing technical problems.')
+      );
+      after(() => helper.app.set('env', env));
+    });
   });
 });

--- a/test/integration/support/integrationSpecHelper.js
+++ b/test/integration/support/integrationSpecHelper.js
@@ -33,7 +33,7 @@ module.exports = {
   googleTagManagerHelper: new GoogleTagManagerHelper(browser),
   dashboardPage: new DashboardPage({ browser, routes }),
   searchPage: new SearchPage({ browser, routes }),
-  errorPage: new ErrorPage({ browser }),
+  errorPage: new ErrorPage({ browser, routes }),
   cookiePage: new CookiePage({ browser, routes }),
   detailPage: new DetailPage({ browser, routes }),
   entrypointPage: new EntrypointPage({ browser, routes }),

--- a/test/integration/support/routes.js
+++ b/test/integration/support/routes.js
@@ -9,6 +9,8 @@ function create({ basePath, siteUrl }) {
       `${siteUrl}${basePath}/search?search=${encodeURIComponent(search)}`,
     detailsUrl: (resourceId, search) =>
       `${basePath}/resources/${resourceId}?fromSearch=${encodeURIComponent(search)}`,
+    errorUrl: (errorId) =>
+      `${basePath}/error/${errorId}`,
   };
 }
 


### PR DESCRIPTION
* Throw 404 for resource not found
* Deduplicate slashes in url to avoid 404 for /resources/octo003///
* Add 404 specific error view

To test, hit the following:

URL: /resources/blahblah
Expected: fancy page not found message

URL: /some-other-stuff/that/does/not-exist
Expected: fancy page not found message

URL: /resources/octo003///
Expected: octo003 resource